### PR TITLE
Add tests and testing framework

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Cololight Dev",
+	"context": "..",
+	"dockerFile": "../Dockerfile.dev",
+	"runArgs": ["-e", "GIT_EDITOR=code --wait"],
+	"extensions": [
+	  "ms-python.python",
+	  "visualstudioexptteam.vscodeintellicode",
+	  "redhat.vscode-yaml",
+	  "esbenp.prettier-vscode"
+	],
+	"settings": {
+	  "python.pythonPath": "/usr/local/bin/python",
+	  "python.linting.pylintEnabled": true,
+	  "python.linting.enabled": true,
+	  "python.formatting.provider": "black",
+	  "editor.formatOnPaste": false,
+	  "editor.formatOnSave": true,
+	  "editor.formatOnType": true,
+	  "files.trimTrailingWhitespace": true,
+	  "terminal.integrated.shell.linux": "/bin/bash",
+	}
+  }

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,38 @@
+FROM python:3.8
+
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
+        libudev-dev \
+        libavformat-dev \
+        libavcodec-dev \
+        libavdevice-dev \
+        libavutil-dev \
+        libswscale-dev \
+        libswresample-dev \
+        libavfilter-dev \
+        git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src
+
+# Setup hass-release
+RUN git clone --depth 1 https://github.com/home-assistant/hass-release \
+    && pip3 install -e hass-release/
+
+WORKDIR /homeassistant
+
+# Setup homeassistant framework
+RUN git clone --depth 1 https://github.com/home-assistant/core.git && \
+    pip3 install -r core/requirements_test.txt -c core/homeassistant/package_constraints.txt && \
+    pip3 uninstall -y typing && \
+    core/script/setup && \
+    pip3 install sqlalchemy==1.3.16
+
+WORKDIR /workspaces
+
+RUN ln -s /workspaces/homeassistant_cololight/custom_components/cololight /homeassistant/core/homeassistant/components/cololight
+
+# Set the default shell to bash instead of sh
+ENV PYTHONPATH /workspaces/homeassistant_cololight/custom_components
+ENV SHELL /bin/bash

--- a/README.md
+++ b/README.md
@@ -27,20 +27,20 @@ Custom component to support [LifeSmart Cololight](http://www.cololight.com/) in 
 
 ### Options
 
-| Name | Type | Required | Default | Description
-| --- | --- | --- | --- | ---
-| platform | string | ✔ |  | cololight
-| host | string | ✔ | | IP address of your Cololight
-| name | string | ✖ | Cololight | name of your entity
+| Name     | Type   | Required | Default   | Description                  |
+| -------- | ------ | -------- | --------- | ---------------------------- |
+| platform | string | ✔        |           | cololight                    |
+| host     | string | ✔        |           | IP address of your Cololight |
+| name     | string | ✖        | Cololight | name of your entity          |
 
 Add a light to your configuration:
 
-~~~ yaml
+```yaml
 light:
   - platform: cololight
     name: my_cololight
     host: 192.168.1.100
-~~~~
+```
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -45,3 +45,46 @@ light:
 ## Credits
 
 Thanks to ["Projekt: ColoLight in FHEM"](https://haus-automatisierung.com/projekt/2019/04/05/projekt-cololight-fhem.html) for discovering how to talk with the Cololight
+
+## Tests:
+
+This section talks to how to setup and run test to ensure any development changes do not break the component.
+
+**Prerequisites**
+
+- [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- Docker
+  - For Linux, macOS, or Windows 10 Pro/Enterprise/Education use the [current release version of Docker](https://docs.docker.com/install/)
+  - Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for Windows Pro/Enterprise/Education.
+- [Visual Studio code](https://code.visualstudio.com/)
+- [Remote - Containers (VSC Extension)][extension-link]
+
+[More info about requirements and devcontainer in general](https://code.visualstudio.com/docs/remote/containers#_getting-started)
+
+[extension-link]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
+
+**Getting started:**
+
+1. Clone the repository to your computer.
+2. Open the repository using Visual Studio code.
+
+When you open this repository with Visual Studio code you are asked to "Reopen in Container", this will start the build of the container.
+
+_If you don't see this notification, open the command palette and select `Remote-Containers: Reopen Folder in Container`._
+
+**Running Tests:**
+
+Open a terminal in Visual Studio code within the Remote-Containers session.
+Tests can then be run using pytest.
+
+Run all test:
+
+```
+pytest
+```
+
+Run individual test:
+
+```
+pytest tests/test_light.py::test_turn_on
+```

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -111,6 +111,9 @@ class coloLight(Light):
     def hs_color(self) -> tuple:
         return self._hs
 
+    def send_message(self, message):
+        self._sock.sendto(message, (self._host, self._port))
+
     async def async_turn_on(self, **kwargs):
         hs_color = kwargs.get(ATTR_HS_COLOR)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
@@ -120,25 +123,23 @@ class coloLight(Light):
 
         if rgb:
             self._hs = hs_color
-            self._sock.sendto(
+            self.send_message(
                 bytes.fromhex(
                     "{}{}{:02x}{:02x}{:02x}".format(
                         MESSAGE_PREFIX, MESSAGE_COMMAND_COLOR, *rgb
                     )
-                ),
-                (self._host, self._port),
+                )
             )
 
         if effect:
-            self._sock.sendto(
+            self.send_message(
                 bytes.fromhex(
                     "{}{}{}".format(
                         MESSAGE_PREFIX,
                         MESSAGE_COMMAND_EFFECT,
                         COLOLIGHT_EFFECT_MAPPING[effect],
                     )
-                ),
-                (self._host, self._port),
+                )
             )
 
         if brightness:
@@ -146,7 +147,7 @@ class coloLight(Light):
 
         brightness = (self._brightness / 255) * 100
 
-        self._sock.sendto(
+        self.send_message(
             bytes.fromhex(
                 "{}{}{}{:02x}".format(
                     MESSAGE_PREFIX,
@@ -154,16 +155,14 @@ class coloLight(Light):
                     MESSAGE_BRIGHTNESS,
                     int(brightness),
                 )
-            ),
-            (self._host, self._port),
+            )
         )
         self._on = True
 
     async def async_turn_off(self, **kwargs):
-        self._sock.sendto(
+        self.send_message(
             bytes.fromhex(
                 "{}{}{}".format(MESSAGE_PREFIX, MESSAGE_COMMAND_CONFIG, MESSAGE_OFF)
-            ),
-            (self._host, self._port),
+            )
         )
         self._on = False

--- a/custom_components/cololight/light.py
+++ b/custom_components/cololight/light.py
@@ -83,6 +83,7 @@ class coloLight(Light):
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._supported_features = SUPPORT_BRIGHTNESS | SUPPORT_COLOR | SUPPORT_EFFECT
         self._effect_list = COLOLIGHT_EFFECT_LIST
+        self._effect = None
         self._on = False
         self._brightness = 255
         self._hs = None
@@ -102,6 +103,10 @@ class coloLight(Light):
     @property
     def effect_list(self):
         return self._effect_list
+
+    @property
+    def effect(self):
+        return self._effect
 
     @property
     def brightness(self) -> int:
@@ -132,6 +137,7 @@ class coloLight(Light):
             )
 
         if effect:
+            self._effect = effect
             self.send_message(
                 bytes.fromhex(
                     "{}{}{}".format(

--- a/custom_components/tests/test_light.py
+++ b/custom_components/tests/test_light.py
@@ -1,0 +1,154 @@
+import pytest
+import socket
+import sys
+
+import cololight
+
+from unittest.mock import patch, call
+
+# Link to homeassistant module
+sys.path.insert(1, "/homeassistant/core")
+from tests.conftest import hass, hass_storage
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_EFFECT,
+    ATTR_HS_COLOR,
+    DOMAIN as LIGHT_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.setup import async_setup_component
+
+CONF_NAME = "cololight_test"
+ENTITY_LIGHT = f"light.{CONF_NAME}"
+
+
+@pytest.fixture(autouse=True)
+@patch("socket.socket")
+def setup_comp(mock_socket, hass):
+    """Set up cololight component."""
+    hass.loop.run_until_complete(
+        async_setup_component(
+            hass,
+            LIGHT_DOMAIN,
+            {
+                LIGHT_DOMAIN: {
+                    "platform": "cololight",
+                    "name": CONF_NAME,
+                    "host": "1.1.1.1",
+                }
+            },
+        )
+    )
+
+
+@patch("homeassistant.components.cololight.light.coloLight.send_message")
+async def test_turn_on(mock_sending, hass):
+    """Test the light turns of successfully."""
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_LIGHT}, blocking=True,
+    )
+
+    state = hass.states.get(ENTITY_LIGHT)
+
+    mock_sending.assert_called_with(
+        b"SZ00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x01\x03\x01\xcfd"
+    )
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 255
+
+
+@patch("homeassistant.components.cololight.light.coloLight.send_message")
+async def test_turn_on_with_brightness(mock_sending, hass):
+    """Test the light turns on to the specified brightness."""
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_BRIGHTNESS: 60},
+        blocking=True,
+    )
+
+    state = hass.states.get(ENTITY_LIGHT)
+
+    mock_sending.assert_called_with(
+        b"SZ00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x01\x03\x01\xcf\x17"
+    )
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 60
+
+
+@patch("homeassistant.components.cololight.light.coloLight.send_message")
+async def test_turn_on_with_effect(mock_sending, hass):
+    """Test the light turns on with effect."""
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_EFFECT: "Sunrise", ATTR_BRIGHTNESS: 60},
+        blocking=True,
+    )
+
+    state = hass.states.get(ENTITY_LIGHT)
+
+    expected_messages = [
+        call(
+            b"SZ00\x00\x00\x00\x00\x00#\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x01\x06\x02\xff\x01\xc1\n\x00"
+        ),
+        call(
+            b"SZ00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x01\x03\x01\xcf\x17"
+        ),
+    ]
+    mock_sending.assert_has_calls(expected_messages)
+    assert mock_sending.call_count == 2
+
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 60
+    assert state.attributes.get(ATTR_EFFECT) == "Sunrise"
+
+
+@patch("homeassistant.components.cololight.light.coloLight.send_message")
+async def test_turn_on_with_colour(mock_sending, hass):
+    """Test the light turns on with colour."""
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_HS_COLOR: (180, 50), ATTR_BRIGHTNESS: 60},
+        blocking=True,
+    )
+
+    state = hass.states.get(ENTITY_LIGHT)
+
+    expected_messages = [
+        call(
+            b"SZ00\x00\x00\x00\x00\x00#\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x01\x06\x02\xff\x00\x7f\xff\xff"
+        ),
+        call(
+            b"SZ00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x01\x03\x01\xcf\x17"
+        ),
+    ]
+    mock_sending.assert_has_calls(expected_messages)
+    assert mock_sending.call_count == 2
+
+    assert state.state == STATE_ON
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 60
+    assert state.attributes.get(ATTR_HS_COLOR) == (180, 50)
+
+
+@patch("homeassistant.components.cololight.light.coloLight.send_message")
+async def test_turn_off(mock_sending, hass):
+    """Test the light turns off successfully."""
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_LIGHT}, blocking=True,
+    )
+
+    state = hass.states.get(ENTITY_LIGHT)
+
+    mock_sending.assert_called_with(
+        b"SZ00\x00\x00\x00\x00\x00 \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x04\x01\x03\x01\xce\x1e"
+    )
+    assert state.state == STATE_OFF


### PR DESCRIPTION
## summary of the change

- Add testing framework
- Add tests
- Refactor light, adding send_message method & effect property 

This PR setups up the testing framework and add tests, testing the existing functionality.
This will allow for refactoring of the code, ensuing we don't break the existing functionality of the light.

The README has been updated with tasks necessary to run the tests.
The testing framework pulls HA core, so that it is able to access HA testing stubs, in order to mock the running of HA.